### PR TITLE
minor: Optional keep flag 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-and-publish:

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>2.0.3</Version>
+    <Version>2.0.4-optional-keep</Version>
     <Authors>Marko Urh</Authors>
     <Company>Perun</Company>
     <Copyright>Copyright (c) 2023 Marko Urh and other authors.</Copyright>

--- a/source/Perun.Differ.Tests/DifferTests.cs
+++ b/source/Perun.Differ.Tests/DifferTests.cs
@@ -443,6 +443,54 @@ namespace Differ.DotNet.Tests
         }
 
         [Fact]
+        public void OptionalKeepDiff_Simple_NoSiblingChanges_Ignores()
+        {
+            var faker = new AutoFaker<SimpleOptionalKeepModel>();
+            var left = faker.UseSeed(1).Generate();
+
+            var diff = DifferDotNet.Diff(left, left).SingleOrDefault();
+
+            Assert.Null(diff);
+        }
+
+        [Fact]
+        public void OptionalKeepDiff_Simple_SiblingChanges_DoesNotIgnore()
+        {
+            var faker = new AutoFaker<SimpleOptionalKeepModel>();
+            var left = faker.UseSeed(1).Generate();
+            var right = faker.UseSeed(2).Generate();
+
+            var diffs = DifferDotNet.Diff(left, right);
+
+            Assert.Equal(2, diffs.Count());
+        }
+
+        [Fact]
+        public void OptionalKeepDiff_Complex_NoSiblingChange_Ignores()
+        {
+            var faker = new AutoFaker<ComplexOptionalKeepModel>();
+            var left = faker.UseSeed(1).Generate();
+
+            var diff = DifferDotNet.Diff(left, left).SingleOrDefault();
+
+            Assert.Null(diff);
+        }
+
+        [Fact]
+        public void OptionalKeepDiff_Complex_ChildChange_DoesNotIgnore()
+        {
+            var faker = new AutoFaker<ComplexOptionalKeepModel>();
+            var left = faker.UseSeed(1).Generate();
+            var right = faker.UseSeed(2).Generate();
+
+            right.NoDiff = left.NoDiff;
+
+            var diff = DifferDotNet.Diff(left, right);
+
+            Assert.NotNull(diff.SingleOrDefault());
+        }
+
+        [Fact]
         public void KeepDiff_Simple_Keeps()
         {
             var faker = new AutoFaker<SimpleKeepModel>();
@@ -453,6 +501,7 @@ namespace Differ.DotNet.Tests
             Assert.Equal(left.NoDiffKeepMe, diff.LeftValue);
             Assert.Equal(left.NoDiffKeepMe, diff.RightValue);
             Assert.Equal(diff.LeftValue, diff.RightValue);
+            Assert.False(diff.IgnoreIfNoOtherDiff);
         }
 
         [Fact]
@@ -464,6 +513,7 @@ namespace Differ.DotNet.Tests
             var diffs = DifferDotNet.Diff(left, left).ToList();
 
             Assert.Equal(left.NoDiffKeepMe.Count(), diffs.Count);
+            Assert.True(diffs.TrueForAll(x => !x.IgnoreIfNoOtherDiff));
         }
 
         [Fact]
@@ -475,6 +525,7 @@ namespace Differ.DotNet.Tests
             var diffs = DifferDotNet.Diff(left, left).ToList();
 
             Assert.Equal(left.NoDiffKeepMe.Count(), diffs.Count);
+            Assert.True(diffs.TrueForAll(x => !x.IgnoreIfNoOtherDiff));
         }
 
         [Fact]
@@ -487,6 +538,7 @@ namespace Differ.DotNet.Tests
 
             var expectedDiffCount = left.NoDiffKeepMe.GetType().GetProperties().Length;
             Assert.Equal(expectedDiffCount, diffs.Count);
+            Assert.True(diffs.TrueForAll(x => !x.IgnoreIfNoOtherDiff));
         }
 
         [Fact]

--- a/source/Perun.Differ.Tests/TestTypes/KeepAttributeModels.cs
+++ b/source/Perun.Differ.Tests/TestTypes/KeepAttributeModels.cs
@@ -33,4 +33,20 @@ namespace Differ.DotNet.Tests.TestTypes
 
         public ComplexType NoDiff { get; set; }
     }
+
+    public class SimpleOptionalKeepModel
+    {
+        [KeepInDiff(IgnoreIfNoOtherDiff = true)]
+        public string NoDiffKeepMe { get; set; }
+
+        public string NoDiff { get; set; }
+    }
+
+    public class ComplexOptionalKeepModel
+    {
+        [KeepInDiff(IgnoreIfNoOtherDiff = true)]
+        public ComplexType NoDiffKeepMe { get; set; }
+
+        public ComplexType NoDiff { get; set; }
+    }
 }

--- a/source/Perun.Differ/Attributes.cs
+++ b/source/Perun.Differ/Attributes.cs
@@ -11,6 +11,14 @@ namespace Differ.DotNet
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class KeepInDiffAttribute : Attribute
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether attribute should be ignored if sibling or child diffs exist.
+        /// </summary>
+        /// <value>
+        ///     If <c>true</c> attribute is ignored (not kept), if no sibling or child diffs exist.
+        ///     If <c>false</c> values are always kept.
+        /// </value>
+        public bool IgnoreIfNoOtherDiff { get; set; }
     }
 
     /// <summary>
@@ -43,16 +51,15 @@ namespace Differ.DotNet
     {
         Default = 0,
         Keep = 1,
-        Ignore = 2
+        Ignore = 2,
+        KeepOptional = 4,
     }
 
     internal sealed class DiffCollection
     {
-        public Dictionary<string, Difference> Diffs { get; set; } = new Dictionary<string, Difference>();
+        public Dictionary<string, Difference> Diffs { get; set; } = new(); // (FullPath, Diff)
 
-        public List<Difference> KeepDiffs { get; set; } = new List<Difference>();
-        public HashSet<string> KeepPaths { get; set; } = new HashSet<string>();
-
-        public HashSet<string> IgnorePaths { get; set; } = new HashSet<string>();
+        public HashSet<Difference> KeepDiffs { get; set; } = new();
+        public HashSet<string> IgnorePaths { get; set; } = new(); // FullPath
     }
 }

--- a/source/Perun.Differ/DifferDotNet.cs
+++ b/source/Perun.Differ/DifferDotNet.cs
@@ -94,12 +94,11 @@ namespace Differ.DotNet
                 }
 
                 // Check for KeepInDiff attribute
-                if (prop.GetCustomAttribute<KeepInDiffAttribute>() != null)
+                if (prop.GetCustomAttribute<KeepInDiffAttribute>() is { } keepAtt)
                 {
-                    if (!diffs.KeepPaths.Contains(fullPath))
-                        diffs.KeepPaths.Add(fullPath);
-
-                    actions |= DiffActions.Keep;
+                    actions |= keepAtt.IgnoreIfNoOtherDiff
+                        ? DiffActions.KeepOptional
+                        : DiffActions.Keep;
                 }
 
                 // Recurse on sub-objects
@@ -176,8 +175,10 @@ namespace Differ.DotNet
                 rightObj
             );
 
-            if (actions.HasFlag(DiffActions.Keep))
+            if (actions.HasFlag(DiffActions.Keep) || actions.HasFlag(DiffActions.KeepOptional))
             {
+                diff.IgnoreIfNoOtherDiff = actions.HasFlag(DiffActions.KeepOptional);
+                diff.Keep = true;
                 diffs.KeepDiffs.Add(diff);
             }
 

--- a/source/Perun.Differ/Difference.cs
+++ b/source/Perun.Differ/Difference.cs
@@ -49,5 +49,11 @@ namespace Differ.DotNet
 
             return (fullPath, fieldName, fieldPath);
         }
+
+        /// assembly internals
+
+        internal bool IgnoreIfNoOtherDiff { get; set; }
+        internal bool Keep { get; set; }
+        internal bool Ignore { get; set; }
     }
 }

--- a/source/Perun.Differ/Extensions.cs
+++ b/source/Perun.Differ/Extensions.cs
@@ -9,6 +9,17 @@ namespace Differ.DotNet
 {
     internal static class Extensions
     {
+        internal static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key, TValue value)
+        {
+            if (dict.ContainsKey(key))
+            {
+                dict.Add(key, value);
+                return true;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Reference: https://stackoverflow.com/a/65079923
         /// </summary>

--- a/source/Perun.Differ/Trie.cs
+++ b/source/Perun.Differ/Trie.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Differ.DotNet
+{
+    [Serializable]
+    public class Trie<TValue> : TrieNode<TValue>
+    {
+        public IEnumerable<TValue> Retrieve(string query)
+        {
+            return Retrieve(query, 0);
+        }
+
+        public void Add(string key, TValue value)
+        {
+            Add(key, 0, value);
+        }
+    }
+
+    [Serializable]
+    public class TrieNode<TValue> : TrieNodeBase<TValue>
+    {
+        private readonly Dictionary<char, TrieNode<TValue>> m_Children;
+        private readonly Queue<TValue> m_Values;
+
+        protected TrieNode()
+        {
+            m_Children = new Dictionary<char, TrieNode<TValue>>();
+            m_Values = new Queue<TValue>();
+        }
+
+        protected override int KeyLength
+        {
+            get { return 1; }
+        }
+
+        protected override IEnumerable<TrieNodeBase<TValue>> Children()
+        {
+            return m_Children.Values;
+        }
+
+        protected override IEnumerable<TValue> Values()
+        {
+            return m_Values;
+        }
+
+        protected override TrieNodeBase<TValue> GetOrCreateChild(char key)
+        {
+            TrieNode<TValue> result;
+            if (!m_Children.TryGetValue(key, out result))
+            {
+                result = new TrieNode<TValue>();
+                m_Children.Add(key, result);
+            }
+            return result;
+        }
+
+        protected override TrieNodeBase<TValue> GetChildOrNull(string query, int position)
+        {
+            if (query == null) throw new ArgumentNullException("query");
+            TrieNode<TValue> childNode;
+            return
+                m_Children.TryGetValue(query[position], out childNode)
+                    ? childNode
+                    : null;
+        }
+
+        protected override void AddValue(TValue value)
+        {
+            m_Values.Enqueue(value);
+        }
+    }
+
+    [Serializable]
+    public abstract class TrieNodeBase<TValue>
+    {
+        protected abstract int KeyLength { get; }
+
+        protected abstract IEnumerable<TValue> Values();
+
+        protected abstract IEnumerable<TrieNodeBase<TValue>> Children();
+
+        public long Size()
+        {
+            return Children().Sum(o => o.Size()) + 1;
+        }
+
+        public void Add(string key, int position, TValue value)
+        {
+            if (key == null) throw new ArgumentNullException("key");
+            if (EndOfString(position, key))
+            {
+                AddValue(value);
+                return;
+            }
+
+            var child = GetOrCreateChild(key[position]);
+            child.Add(key, position + 1, value);
+        }
+
+        protected abstract void AddValue(TValue value);
+
+        protected abstract TrieNodeBase<TValue> GetOrCreateChild(char key);
+
+        protected virtual IEnumerable<TValue> Retrieve(string query, int position)
+        {
+            return
+                EndOfString(position, query)
+                    ? ValuesDeep()
+                    : SearchDeep(query, position);
+        }
+
+        protected virtual IEnumerable<TValue> SearchDeep(string query, int position)
+        {
+            var nextNode = GetChildOrNull(query, position);
+            return nextNode != null
+                       ? nextNode.Retrieve(query, position + nextNode.KeyLength)
+                       : Enumerable.Empty<TValue>();
+        }
+
+        protected abstract TrieNodeBase<TValue> GetChildOrNull(string query, int position);
+
+        private static bool EndOfString(int position, string text)
+        {
+            return position >= text.Length;
+        }
+
+        private IEnumerable<TValue> ValuesDeep()
+        {
+            return
+                Subtree()
+                    .SelectMany(node => node.Values());
+        }
+
+        protected IEnumerable<TrieNodeBase<TValue>> Subtree()
+        {
+            return
+                Enumerable.Repeat(this, 1)
+                    .Concat(Children().SelectMany(child => child.Subtree()));
+        }
+    }
+}

--- a/source/Perun.Differ/Trie.cs
+++ b/source/Perun.Differ/Trie.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace Differ.DotNet
 {
     [Serializable]
-    public class Trie<TValue> : TrieNode<TValue>
+    internal sealed class Trie<TValue> : TrieNode<TValue>
     {
         public IEnumerable<TValue> Retrieve(string query)
         {
@@ -19,7 +19,7 @@ namespace Differ.DotNet
     }
 
     [Serializable]
-    public class TrieNode<TValue> : TrieNodeBase<TValue>
+    internal class TrieNode<TValue> : TrieNodeBase<TValue>
     {
         private readonly Dictionary<char, TrieNode<TValue>> m_Children;
         private readonly Queue<TValue> m_Values;
@@ -73,7 +73,7 @@ namespace Differ.DotNet
     }
 
     [Serializable]
-    public abstract class TrieNodeBase<TValue>
+    internal abstract class TrieNodeBase<TValue>
     {
         protected abstract int KeyLength { get; }
 


### PR DESCRIPTION
Allows to mark prop for keep only if it's siblings or children have any diffing values, otherwise diff is discarded as ignored because it carries no diffing value without additional context.