### PR TITLE
feat: support deep dictionary diff 

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>2.1.5</Version>
+    <Version>2.2.0</Version>
     <Authors>Marko Urh</Authors>
     <Company>Perun</Company>
     <Copyright>Copyright (c) 2023 Marko Urh and other authors.</Copyright>

--- a/source/Perun.Differ.Tests/DifferTests.cs
+++ b/source/Perun.Differ.Tests/DifferTests.cs
@@ -135,10 +135,7 @@ namespace Differ.DotNet.Tests
             faker.RuleForType(typeof(IList), x => x.Random.WordsArray(3).ToList() as IList);
             faker.RuleForType(typeof(IEnumerable), x => x.Random.WordsArray(3).ToList() as IEnumerable);
             faker.RuleForType(typeof(ICollection), x => x.Random.WordsArray(3).ToList() as ICollection);
-            //faker.RuleForType(typeof(IDictionary), x => x.Make(3, () =>
-            //        new KeyValuePair<string, string>(x.Random.Word(), x.Random.Word()))
-            //        .ToDictionary(x => x.Key, x => x.Value) as IDictionary
-            //);
+
             faker.RuleForType(typeof(Collection), x => new Collection
             {
                 x.Random.Word(),
@@ -178,12 +175,6 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(SimpleIterableTypes.ArrayGeneric).ToLower()].ToList()
             );
 
-            //Extensions.AssertIterable(
-            //    left.DictionaryGeneric,
-            //    right.DictionaryGeneric,
-            //    diffsLookup[nameof(SimpleIterableTypes.DictionaryGeneric).ToLower()].ToList()
-            //);
-
             Extensions.AssertIterable(
                 left.EnumerableGeneric,
                 right.EnumerableGeneric,
@@ -202,23 +193,17 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(SimpleIterableTypes.CollectionGenericTyped).ToLower()].ToList()
             );
 
-            //Extensions.AssertIterable(
-            //    left.DictionaryGenericTyped,
-            //    right.DictionaryGenericTyped,
-            //    diffsLookup[nameof(SimpleIterableTypes.DictionaryGenericTyped).ToLower()].ToList()
-            //);
+            Extensions.AssertIterable(
+                left.SetGeneric,
+                right.SetGeneric,
+                diffsLookup[nameof(SimpleIterableTypes.SetGeneric).ToLower()].ToList()
+            );
 
-            //Extensions.AssertIterable(
-            //    left.SetGeneric,
-            //    right.SetGeneric,
-            //    diffsLookup[nameof(SimpleIterableTypes.SetGeneric).ToLower()].ToList()
-            //);
-
-            //Extensions.AssertIterable(
-            //    left.SetTyped,
-            //    right.SetTyped,
-            //    diffsLookup[nameof(SimpleIterableTypes.SetTyped).ToLower()].ToList()
-            //);
+            Extensions.AssertIterable(
+                left.SetTyped,
+                right.SetTyped,
+                diffsLookup[nameof(SimpleIterableTypes.SetTyped).ToLower()].ToList()
+            );
 
             Extensions.AssertIterable(
                 (IEnumerable<string>)left.Collection,
@@ -243,12 +228,6 @@ namespace Differ.DotNet.Tests
                 (IEnumerable<string>)right.Enumerable,
                 diffsLookup[nameof(SimpleIterableTypes.Enumerable).ToLower()].ToList()
             );
-
-            //Extensions.AssertIterable(
-            //    (IEnumerable<KeyValuePair<string, string>>)left.Dictionary,
-            //    (IEnumerable<KeyValuePair<string, string>>)right.Dictionary,
-            //    diffsLookup[nameof(SimpleIterableTypes.Dictionary).ToLower()].ToList()
-            //);
         }
 
         [Fact]
@@ -347,10 +326,7 @@ namespace Differ.DotNet.Tests
             faker.RuleForType(typeof(IList), x => complexFaker.Generate(3).ToList() as IList);
             faker.RuleForType(typeof(IEnumerable), x => complexFaker.Generate(3).ToList() as IEnumerable);
             faker.RuleForType(typeof(ICollection), x => complexFaker.Generate(3).ToList() as ICollection);
-            //faker.RuleForType(typeof(IDictionary), x => x.Make(3, () =>
-            //        new KeyValuePair<ComplexType, ComplexType>(complexFaker.Generate(), complexFaker.Generate()))
-            //    .ToDictionary(x => x.Key, x => x.Value) as IDictionary
-            //);
+
             faker.RuleForType(typeof(Collection), x => new Collection
             {
                 complexFaker.Generate(),
@@ -390,12 +366,6 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(ComplexIterableTypes.ArrayGeneric).ToLower()].ToList()
             );
 
-            //Extensions.AssertIterable(
-            //    left.DictionaryGeneric,
-            //    right.DictionaryGeneric,
-            //    diffsLookup[nameof(ComplexIterableTypes.DictionaryGeneric).ToLower()].ToList()
-            //);
-
             Extensions.AssertIterable(
                 left.EnumerableGeneric.Select(x => x.String),
                 right.EnumerableGeneric.Select(x => x.String),
@@ -414,23 +384,17 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(ComplexIterableTypes.CollectionGenericTyped).ToLower()].ToList()
             );
 
-            //Extensions.AssertIterable(
-            //    left.DictionaryGenericTyped,
-            //    right.DictionaryGenericTyped,
-            //    diffsLookup[nameof(ComplexIterableTypes.DictionaryGenericTyped).ToLower()].ToList()
-            //);
+            Extensions.AssertIterable(
+                left.SetGeneric.Select(x => x.String),
+                right.SetGeneric.Select(x => x.String),
+                diffsLookup[nameof(ComplexIterableTypes.SetGeneric).ToLower()].ToList()
+            );
 
-            //Extensions.AssertIterable(
-            //    left.SetGeneric.Select(x => x.String),
-            //    right.SetGeneric.Select(x => x.String),
-            //    diffsLookup[nameof(ComplexIterableTypes.SetGeneric).ToLower()].ToList()
-            //);
-
-            //Extensions.AssertIterable(
-            //    left.SetTyped.Select(x => x.String),
-            //    right.SetTyped.Select(x => x.String),
-            //    diffsLookup[nameof(ComplexIterableTypes.SetTyped).ToLower()].ToList()
-            //);
+            Extensions.AssertIterable(
+                left.SetTyped.Select(x => x.String),
+                right.SetTyped.Select(x => x.String),
+                diffsLookup[nameof(ComplexIterableTypes.SetTyped).ToLower()].ToList()
+            );
 
             Extensions.AssertIterable(
                 ((IEnumerable<ComplexType>)left.Collection).Select(x => x.String),
@@ -455,12 +419,6 @@ namespace Differ.DotNet.Tests
                 ((IEnumerable<ComplexType>)right.Enumerable).Select(x => x.String),
                 diffsLookup[nameof(ComplexIterableTypes.Enumerable).ToLower()].ToList()
             );
-
-            //Extensions.AssertIterable(
-            //    (IEnumerable<KeyValuePair<ComplexType, ComplexType>>)left.Dictionary,
-            //    (IEnumerable<KeyValuePair<ComplexType, ComplexType>>)right.Dictionary,
-            //    diffsLookup[nameof(ComplexIterableTypes.Dictionary).ToLower()].ToList()
-            //);
         }
 
         [Fact]
@@ -505,17 +463,11 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(SimpleIterableTypes.EnumerableGeneric).ToLower()].ToList()
             );
 
-            //Extensions.AssertIterable(
-            //    left.SetGeneric.SelectMany(x => x),
-            //    right.SetGeneric.SelectMany(x => x),
-            //    diffsLookup[nameof(SimpleIterableTypes.SetGeneric).ToLower()].ToList()
-            //);
-
-            //Extensions.AssertIterable(
-            //    left.DictionaryGeneric,
-            //    right.DictionaryGeneric,
-            //    diffsLookup[nameof(SimpleIterableTypes.DictionaryGeneric).ToLower()].ToList()
-            //);
+            Extensions.AssertIterable(
+                left.SetGeneric.SelectMany(x => x),
+                right.SetGeneric.SelectMany(x => x),
+                diffsLookup[nameof(SimpleIterableTypes.SetGeneric).ToLower()].ToList()
+            );
         }
 
         [Fact]
@@ -828,22 +780,63 @@ namespace Differ.DotNet.Tests
         {
             var faker = new AutoFaker<ComplexType>();
 
-            var left = new DictionaryOfComplexType
-            {
-                Data = { ["key"] = faker.UseSeed(1).Generate() }
-            };
-
-            var right = new DictionaryOfComplexType
-            {
-                Data = { ["key"] = faker.UseSeed(2).Generate() }
-            };
+            var left = new Dictionary<string, ComplexType> { ["key"] = faker.UseSeed(1).Generate() };
+            IDictionary<string, ComplexType> right = new Dictionary<string, ComplexType> { ["key"] = faker.UseSeed(2).Generate() };
 
             var diff = DifferDotNet.Diff(left, right).Single();
 
-            Assert.Equal(left.Data["key"].String, diff.LeftValue);
-            Assert.Equal(right.Data["key"].String, diff.RightValue);
+            Assert.Equal(left["key"].String, diff.LeftValue);
+            Assert.Equal(right["key"].String, diff.RightValue);
 
-            Assert.Equal("data.key.string", diff.FullPath);
+            Assert.Equal("key.string", diff.FullPath);
+        }
+
+        [Fact]
+        public void Dictionary_SimpleKey_SimpleValue_Diffs()
+        {
+            var left = new Dictionary<string, string> { ["key"] = "value1" };
+            IDictionary<string, string> right = new Dictionary<string, string> { ["key"] = "value2" };
+
+            var diff = DifferDotNet.Diff(left, right).Single();
+
+            Assert.Equal(left["key"], diff.LeftValue);
+            Assert.Equal(right["key"], diff.RightValue);
+
+            Assert.Equal("key", diff.FullPath);
+        }
+
+        [Fact]
+        public void Dictionary_ComplexKey_SimpleValue_Diffs()
+        {
+            var faker = new AutoFaker<ComplexTypeWithToStringOverride>();
+            var key = faker.UseSeed(1).Generate();
+
+            var left = new Dictionary<ComplexTypeWithToStringOverride, string> { [key] = "value1" };
+            var right = new Dictionary<ComplexTypeWithToStringOverride, string> { [key] = "value2" };
+
+            var diff = DifferDotNet.Diff(left, right).Single();
+
+            Assert.Equal(left[key], diff.LeftValue);
+            Assert.Equal(right[key], diff.RightValue);
+
+            Assert.Equal(ComplexTypeWithToStringOverride.Name(), diff.FullPath);
+        }
+
+        [Fact]
+        public void Dictionary_ComplexKey_ComplexValue_Diffs()
+        {
+            var faker = new AutoFaker<ComplexTypeWithToStringOverride>();
+            var key = faker.UseSeed(1).Generate();
+
+            var left = new Dictionary<ComplexTypeWithToStringOverride, ComplexTypeWithToStringOverride> { [key] = faker.UseSeed(2).Generate() };
+            var right = new Dictionary<ComplexTypeWithToStringOverride, ComplexTypeWithToStringOverride> { [key] = faker.UseSeed(3).Generate() };
+
+            var diff = DifferDotNet.Diff(left, right).Single();
+
+            Assert.Equal(left[key].String, diff.LeftValue);
+            Assert.Equal(right[key].String, diff.RightValue);
+
+            Assert.Equal($"{ComplexTypeWithToStringOverride.Name()}.string", diff.FullPath);
         }
     }
 }

--- a/source/Perun.Differ.Tests/DifferTests.cs
+++ b/source/Perun.Differ.Tests/DifferTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using AutoBogus;
@@ -136,10 +135,10 @@ namespace Differ.DotNet.Tests
             faker.RuleForType(typeof(IList), x => x.Random.WordsArray(3).ToList() as IList);
             faker.RuleForType(typeof(IEnumerable), x => x.Random.WordsArray(3).ToList() as IEnumerable);
             faker.RuleForType(typeof(ICollection), x => x.Random.WordsArray(3).ToList() as ICollection);
-            faker.RuleForType(typeof(IDictionary), x => x.Make(3, () =>
-                    new KeyValuePair<string, string>(x.Random.Word(), x.Random.Word()))
-                    .ToDictionary(x => x.Key, x => x.Value) as IDictionary
-            );
+            //faker.RuleForType(typeof(IDictionary), x => x.Make(3, () =>
+            //        new KeyValuePair<string, string>(x.Random.Word(), x.Random.Word()))
+            //        .ToDictionary(x => x.Key, x => x.Value) as IDictionary
+            //);
             faker.RuleForType(typeof(Collection), x => new Collection
             {
                 x.Random.Word(),
@@ -179,11 +178,11 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(SimpleIterableTypes.ArrayGeneric).ToLower()].ToList()
             );
 
-            Extensions.AssertIterable(
-                left.DictionaryGeneric,
-                right.DictionaryGeneric,
-                diffsLookup[nameof(SimpleIterableTypes.DictionaryGeneric).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.DictionaryGeneric,
+            //    right.DictionaryGeneric,
+            //    diffsLookup[nameof(SimpleIterableTypes.DictionaryGeneric).ToLower()].ToList()
+            //);
 
             Extensions.AssertIterable(
                 left.EnumerableGeneric,
@@ -203,23 +202,23 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(SimpleIterableTypes.CollectionGenericTyped).ToLower()].ToList()
             );
 
-            Extensions.AssertIterable(
-                left.DictionaryGenericTyped,
-                right.DictionaryGenericTyped,
-                diffsLookup[nameof(SimpleIterableTypes.DictionaryGenericTyped).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.DictionaryGenericTyped,
+            //    right.DictionaryGenericTyped,
+            //    diffsLookup[nameof(SimpleIterableTypes.DictionaryGenericTyped).ToLower()].ToList()
+            //);
 
-            Extensions.AssertIterable(
-                left.SetGeneric,
-                right.SetGeneric,
-                diffsLookup[nameof(SimpleIterableTypes.SetGeneric).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.SetGeneric,
+            //    right.SetGeneric,
+            //    diffsLookup[nameof(SimpleIterableTypes.SetGeneric).ToLower()].ToList()
+            //);
 
-            Extensions.AssertIterable(
-                left.SetTyped,
-                right.SetTyped,
-                diffsLookup[nameof(SimpleIterableTypes.SetTyped).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.SetTyped,
+            //    right.SetTyped,
+            //    diffsLookup[nameof(SimpleIterableTypes.SetTyped).ToLower()].ToList()
+            //);
 
             Extensions.AssertIterable(
                 (IEnumerable<string>)left.Collection,
@@ -245,11 +244,11 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(SimpleIterableTypes.Enumerable).ToLower()].ToList()
             );
 
-            Extensions.AssertIterable(
-                (IEnumerable<KeyValuePair<string, string>>)left.Dictionary,
-                (IEnumerable<KeyValuePair<string, string>>)right.Dictionary,
-                diffsLookup[nameof(SimpleIterableTypes.Dictionary).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    (IEnumerable<KeyValuePair<string, string>>)left.Dictionary,
+            //    (IEnumerable<KeyValuePair<string, string>>)right.Dictionary,
+            //    diffsLookup[nameof(SimpleIterableTypes.Dictionary).ToLower()].ToList()
+            //);
         }
 
         [Fact]
@@ -348,10 +347,10 @@ namespace Differ.DotNet.Tests
             faker.RuleForType(typeof(IList), x => complexFaker.Generate(3).ToList() as IList);
             faker.RuleForType(typeof(IEnumerable), x => complexFaker.Generate(3).ToList() as IEnumerable);
             faker.RuleForType(typeof(ICollection), x => complexFaker.Generate(3).ToList() as ICollection);
-            faker.RuleForType(typeof(IDictionary), x => x.Make(3, () =>
-                    new KeyValuePair<ComplexType, ComplexType>(complexFaker.Generate(), complexFaker.Generate()))
-                .ToDictionary(x => x.Key, x => x.Value) as IDictionary
-            );
+            //faker.RuleForType(typeof(IDictionary), x => x.Make(3, () =>
+            //        new KeyValuePair<ComplexType, ComplexType>(complexFaker.Generate(), complexFaker.Generate()))
+            //    .ToDictionary(x => x.Key, x => x.Value) as IDictionary
+            //);
             faker.RuleForType(typeof(Collection), x => new Collection
             {
                 complexFaker.Generate(),
@@ -391,11 +390,11 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(ComplexIterableTypes.ArrayGeneric).ToLower()].ToList()
             );
 
-            Extensions.AssertIterable(
-                left.DictionaryGeneric,
-                right.DictionaryGeneric,
-                diffsLookup[nameof(ComplexIterableTypes.DictionaryGeneric).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.DictionaryGeneric,
+            //    right.DictionaryGeneric,
+            //    diffsLookup[nameof(ComplexIterableTypes.DictionaryGeneric).ToLower()].ToList()
+            //);
 
             Extensions.AssertIterable(
                 left.EnumerableGeneric.Select(x => x.String),
@@ -415,23 +414,23 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(ComplexIterableTypes.CollectionGenericTyped).ToLower()].ToList()
             );
 
-            Extensions.AssertIterable(
-                left.DictionaryGenericTyped,
-                right.DictionaryGenericTyped,
-                diffsLookup[nameof(ComplexIterableTypes.DictionaryGenericTyped).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.DictionaryGenericTyped,
+            //    right.DictionaryGenericTyped,
+            //    diffsLookup[nameof(ComplexIterableTypes.DictionaryGenericTyped).ToLower()].ToList()
+            //);
 
-            Extensions.AssertIterable(
-                left.SetGeneric.Select(x => x.String),
-                right.SetGeneric.Select(x => x.String),
-                diffsLookup[nameof(ComplexIterableTypes.SetGeneric).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.SetGeneric.Select(x => x.String),
+            //    right.SetGeneric.Select(x => x.String),
+            //    diffsLookup[nameof(ComplexIterableTypes.SetGeneric).ToLower()].ToList()
+            //);
 
-            Extensions.AssertIterable(
-                left.SetTyped.Select(x => x.String),
-                right.SetTyped.Select(x => x.String),
-                diffsLookup[nameof(ComplexIterableTypes.SetTyped).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.SetTyped.Select(x => x.String),
+            //    right.SetTyped.Select(x => x.String),
+            //    diffsLookup[nameof(ComplexIterableTypes.SetTyped).ToLower()].ToList()
+            //);
 
             Extensions.AssertIterable(
                 ((IEnumerable<ComplexType>)left.Collection).Select(x => x.String),
@@ -457,11 +456,11 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(ComplexIterableTypes.Enumerable).ToLower()].ToList()
             );
 
-            Extensions.AssertIterable(
-                (IEnumerable<KeyValuePair<ComplexType, ComplexType>>)left.Dictionary,
-                (IEnumerable<KeyValuePair<ComplexType, ComplexType>>)right.Dictionary,
-                diffsLookup[nameof(ComplexIterableTypes.Dictionary).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    (IEnumerable<KeyValuePair<ComplexType, ComplexType>>)left.Dictionary,
+            //    (IEnumerable<KeyValuePair<ComplexType, ComplexType>>)right.Dictionary,
+            //    diffsLookup[nameof(ComplexIterableTypes.Dictionary).ToLower()].ToList()
+            //);
         }
 
         [Fact]
@@ -506,17 +505,17 @@ namespace Differ.DotNet.Tests
                 diffsLookup[nameof(SimpleIterableTypes.EnumerableGeneric).ToLower()].ToList()
             );
 
-            Extensions.AssertIterable(
-                left.SetGeneric.SelectMany(x => x),
-                right.SetGeneric.SelectMany(x => x),
-                diffsLookup[nameof(SimpleIterableTypes.SetGeneric).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.SetGeneric.SelectMany(x => x),
+            //    right.SetGeneric.SelectMany(x => x),
+            //    diffsLookup[nameof(SimpleIterableTypes.SetGeneric).ToLower()].ToList()
+            //);
 
-            Extensions.AssertIterable(
-                left.DictionaryGeneric,
-                right.DictionaryGeneric,
-                diffsLookup[nameof(SimpleIterableTypes.DictionaryGeneric).ToLower()].ToList()
-            );
+            //Extensions.AssertIterable(
+            //    left.DictionaryGeneric,
+            //    right.DictionaryGeneric,
+            //    diffsLookup[nameof(SimpleIterableTypes.DictionaryGeneric).ToLower()].ToList()
+            //);
         }
 
         [Fact]
@@ -822,6 +821,29 @@ namespace Differ.DotNet.Tests
             Assert.Equal("b.b.a", diff.FullPath);
             Assert.Equal("b.b", diff.FieldPath);
             Assert.Equal("a", diff.FieldName);
+        }
+
+        [Fact]
+        public void Dictionary_SimpleKey_ComplexValue_Diffs()
+        {
+            var faker = new AutoFaker<ComplexType>();
+
+            var left = new DictionaryOfComplexType
+            {
+                Data = { ["key"] = faker.UseSeed(1).Generate() }
+            };
+
+            var right = new DictionaryOfComplexType
+            {
+                Data = { ["key"] = faker.UseSeed(2).Generate() }
+            };
+
+            var diff = DifferDotNet.Diff(left, right).Single();
+
+            Assert.Equal(left.Data["key"].String, diff.LeftValue);
+            Assert.Equal(right.Data["key"].String, diff.RightValue);
+
+            Assert.Equal("data.key.string", diff.FullPath);
         }
     }
 }

--- a/source/Perun.Differ.Tests/TestTypes/ComplexTypes.cs
+++ b/source/Perun.Differ.Tests/TestTypes/ComplexTypes.cs
@@ -1,4 +1,6 @@
-﻿namespace Differ.DotNet.Tests.TestTypes
+﻿using System.Collections.Generic;
+
+namespace Differ.DotNet.Tests.TestTypes
 {
     public class ComplexType
     {
@@ -8,5 +10,11 @@
     public class NestedComplexType
     {
         public ComplexType Nested { get; set; }
+    }
+
+    public class DictionaryOfComplexType
+    {
+        [DiffCollectionId("Key")]
+        public Dictionary<string, ComplexType> Data { get; set; } = new();
     }
 }

--- a/source/Perun.Differ.Tests/TestTypes/ComplexTypes.cs
+++ b/source/Perun.Differ.Tests/TestTypes/ComplexTypes.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Differ.DotNet.Tests.TestTypes
+﻿namespace Differ.DotNet.Tests.TestTypes
 {
     public class ComplexType
     {
@@ -12,9 +10,18 @@ namespace Differ.DotNet.Tests.TestTypes
         public ComplexType Nested { get; set; }
     }
 
-    public class DictionaryOfComplexType
+    public class ComplexTypeWithToStringOverride
     {
-        [DiffCollectionId("Key")]
-        public Dictionary<string, ComplexType> Data { get; set; } = new();
+        public string String { get; set; }
+
+        public static string Name()
+        {
+            return nameof(ComplexTypeWithToStringOverride);
+        }
+
+        public override string ToString()
+        {
+            return Name();
+        }
     }
 }

--- a/source/Perun.Differ.Tests/TestTypes/IterableModels.cs
+++ b/source/Perun.Differ.Tests/TestTypes/IterableModels.cs
@@ -11,8 +11,8 @@ namespace Differ.DotNet.Tests.TestTypes
         public Array Array { get; set; }
         public string[] ArrayGeneric { get; set; }
 
-        public ISet<string> SetGeneric { get; set; }
-        public HashSet<string> SetTyped { get; set; }
+        //public ISet<string> SetGeneric { get; set; }
+        //public HashSet<string> SetTyped { get; set; }
 
         public IList List { get; set; }
         public List<string> ListGenericTyped { get; set; }
@@ -25,9 +25,9 @@ namespace Differ.DotNet.Tests.TestTypes
         public ICollection<string> CollectionGeneric { get; set; }
         public Collection<string> CollectionGenericTyped { get; set; }
 
-        public IDictionary Dictionary { get; set; }
-        public IDictionary<string, string> DictionaryGeneric { get; set; }
-        public Dictionary<string, string> DictionaryGenericTyped { get; set; }
+        //public IDictionary Dictionary { get; set; }
+        //public IDictionary<string, string> DictionaryGeneric { get; set; }
+        //public Dictionary<string, string> DictionaryGenericTyped { get; set; }
     }
 
     public class ComplexIterableTypes
@@ -35,8 +35,8 @@ namespace Differ.DotNet.Tests.TestTypes
         public Array Array { get; set; }
         public ComplexType[] ArrayGeneric { get; set; }
 
-        public ISet<ComplexType> SetGeneric { get; set; }
-        public HashSet<ComplexType> SetTyped { get; set; }
+        //public ISet<ComplexType> SetGeneric { get; set; }
+        //public HashSet<ComplexType> SetTyped { get; set; }
 
         public IList List { get; set; }
         public List<ComplexType> ListGenericTyped { get; set; }
@@ -50,30 +50,34 @@ namespace Differ.DotNet.Tests.TestTypes
         public ICollection<ComplexType> CollectionGeneric { get; set; }
         public Collection<ComplexType> CollectionGenericTyped { get; set; }
 
-        public IDictionary Dictionary { get; set; }
-        public IDictionary<ComplexType, ComplexType> DictionaryGeneric { get; set; }
+        //public IDictionary Dictionary { get; set; }
+        //public IDictionary<ComplexType, ComplexType> DictionaryGeneric { get; set; }
 
-        public Dictionary<ComplexType, ComplexType> DictionaryGenericTyped { get; set; }
+        //public Dictionary<ComplexType, ComplexType> DictionaryGenericTyped { get; set; }
     }
 
     public class NestedSimpleIterableTypes
     {
         public string[][] ArrayGeneric { get; set; }
-        public ISet<ISet<string>> SetGeneric { get; set; }
+
+        //public ISet<ISet<string>> SetGeneric { get; set; }
         public IList<IList<string>> ListGeneric { get; set; }
+
         public IEnumerable<IEnumerable<string>> EnumerableGeneric { get; set; }
         public ICollection<ICollection<string>> CollectionGeneric { get; set; }
-        public IDictionary<string, IDictionary<string, string>> DictionaryGeneric { get; set; }
+        //public IDictionary<string, IDictionary<string, string>> DictionaryGeneric { get; set; }
     }
 
     public class NestedComplexIterableTypes
     {
         public ComplexType[][] ArrayGeneric { get; set; }
-        public ISet<ISet<ComplexType>> SetGeneric { get; set; }
+
+        //public ISet<ISet<ComplexType>> SetGeneric { get; set; }
         public IList<IList<ComplexType>> ListGeneric { get; set; }
+
         public IEnumerable<IEnumerable<ComplexType>> EnumerableGeneric { get; set; }
         public ICollection<ICollection<ComplexType>> CollectionGeneric { get; set; }
-        public IDictionary<ComplexType, IDictionary<ComplexType, ComplexType>> DictionaryGeneric { get; set; }
+        //public IDictionary<ComplexType, IDictionary<ComplexType, ComplexType>> DictionaryGeneric { get; set; }
     }
 
     public class ComplexIterableWithId

--- a/source/Perun.Differ.Tests/TestTypes/IterableModels.cs
+++ b/source/Perun.Differ.Tests/TestTypes/IterableModels.cs
@@ -51,7 +51,7 @@ namespace Differ.DotNet.Tests.TestTypes
     {
         public string[][] ArrayGeneric { get; set; }
 
-        //public ISet<ISet<string>> SetGeneric { get; set; }
+        public ISet<ISet<string>> SetGeneric { get; set; }
         public IList<IList<string>> ListGeneric { get; set; }
 
         public IEnumerable<IEnumerable<string>> EnumerableGeneric { get; set; }

--- a/source/Perun.Differ.Tests/TestTypes/IterableModels.cs
+++ b/source/Perun.Differ.Tests/TestTypes/IterableModels.cs
@@ -11,8 +11,8 @@ namespace Differ.DotNet.Tests.TestTypes
         public Array Array { get; set; }
         public string[] ArrayGeneric { get; set; }
 
-        //public ISet<string> SetGeneric { get; set; }
-        //public HashSet<string> SetTyped { get; set; }
+        public ISet<string> SetGeneric { get; set; }
+        public HashSet<string> SetTyped { get; set; }
 
         public IList List { get; set; }
         public List<string> ListGenericTyped { get; set; }
@@ -24,10 +24,6 @@ namespace Differ.DotNet.Tests.TestTypes
         public ICollection Collection { get; set; }
         public ICollection<string> CollectionGeneric { get; set; }
         public Collection<string> CollectionGenericTyped { get; set; }
-
-        //public IDictionary Dictionary { get; set; }
-        //public IDictionary<string, string> DictionaryGeneric { get; set; }
-        //public Dictionary<string, string> DictionaryGenericTyped { get; set; }
     }
 
     public class ComplexIterableTypes
@@ -35,8 +31,8 @@ namespace Differ.DotNet.Tests.TestTypes
         public Array Array { get; set; }
         public ComplexType[] ArrayGeneric { get; set; }
 
-        //public ISet<ComplexType> SetGeneric { get; set; }
-        //public HashSet<ComplexType> SetTyped { get; set; }
+        public ISet<ComplexType> SetGeneric { get; set; }
+        public HashSet<ComplexType> SetTyped { get; set; }
 
         public IList List { get; set; }
         public List<ComplexType> ListGenericTyped { get; set; }
@@ -49,11 +45,6 @@ namespace Differ.DotNet.Tests.TestTypes
         public Collection CollectionTyped { get; set; }
         public ICollection<ComplexType> CollectionGeneric { get; set; }
         public Collection<ComplexType> CollectionGenericTyped { get; set; }
-
-        //public IDictionary Dictionary { get; set; }
-        //public IDictionary<ComplexType, ComplexType> DictionaryGeneric { get; set; }
-
-        //public Dictionary<ComplexType, ComplexType> DictionaryGenericTyped { get; set; }
     }
 
     public class NestedSimpleIterableTypes
@@ -65,19 +56,17 @@ namespace Differ.DotNet.Tests.TestTypes
 
         public IEnumerable<IEnumerable<string>> EnumerableGeneric { get; set; }
         public ICollection<ICollection<string>> CollectionGeneric { get; set; }
-        //public IDictionary<string, IDictionary<string, string>> DictionaryGeneric { get; set; }
     }
 
     public class NestedComplexIterableTypes
     {
         public ComplexType[][] ArrayGeneric { get; set; }
 
-        //public ISet<ISet<ComplexType>> SetGeneric { get; set; }
+        public ISet<ISet<ComplexType>> SetGeneric { get; set; }
         public IList<IList<ComplexType>> ListGeneric { get; set; }
 
         public IEnumerable<IEnumerable<ComplexType>> EnumerableGeneric { get; set; }
         public ICollection<ICollection<ComplexType>> CollectionGeneric { get; set; }
-        //public IDictionary<ComplexType, IDictionary<ComplexType, ComplexType>> DictionaryGeneric { get; set; }
     }
 
     public class ComplexIterableWithId

--- a/source/Perun.Differ/DifferDotNet.cs
+++ b/source/Perun.Differ/DifferDotNet.cs
@@ -51,6 +51,11 @@ namespace Differ.DotNet
                 return diffs;
             }
 
+            if (HandleDictionary(path, customPath, prop, type, leftObj, rightObj, diffs, actions))
+            {
+                return diffs;
+            }
+
             if (HandleIterable(path, customPath, prop, type, leftObj, rightObj, diffs, actions))
             {
                 return diffs;
@@ -122,55 +127,111 @@ namespace Differ.DotNet
             return true;
         }
 
-        private static string GetCustomPropertyName<T>(Type type, T left, T right, PropertyInfo prop)
+        private static bool HandleDictionary<T>(
+            string path,
+            string customPath,
+            PropertyInfo prop,
+            Type type,
+            T leftObj, T rightObj,
+            DiffCollection diffs,
+            DiffActions actions
+        )
         {
-            var attr = prop?.GetCustomAttribute<DiffPropertyName>();
-            if (attr is null)
+            if (!type.IsDictionary())
             {
-                return null;
+                return false;
             }
 
-            if (attr.FromPropertyValue == false)
+            var keyType = type.GetGenericArguments()[0];
+            var valueType = type.GetGenericArguments()[1];
+
+            var leftDict = leftObj as IDictionary;
+            var rightDict = rightObj as IDictionary;
+
+            //// Check for DiffArrayIdPropertyName attribute
+            //PropertyInfo idProperty = null;
+            //if (prop != null && prop.GetCustomAttribute<DiffCollectionId>() is { } idAttr)
+            //{
+            //    idProperty = underlyingType?.GetProperty(idAttr.Name);
+            //}
+
+            //// key based
+            //if (idProperty != null)
+            //{
+            //    var leftMap = leftArr.ToDictionary(idProperty.GetValue);
+            //    var rightMap = rightArr.ToDictionary(idProperty.GetValue);
+
+            //    var mapPairs = leftMap.Concat(rightMap).GroupBy(x => x.Key)
+            //        .ToDictionary(
+            //            x => x.Key,
+            //            x => (
+            //                Left: leftMap.ContainsKey(x.Key) ? leftMap[x.Key] : null,
+            //                Right: rightMap.ContainsKey(x.Key) ? rightMap[x.Key] : null
+            //            )
+            //        );
+
+            //    for (var i = 0; i < mapPairs.Count; i++)
+            //    {
+            //        var pair = mapPairs.ElementAt(i);
+            //        var curL = pair.Value.Left;
+            //        var curR = pair.Value.Right;
+
+            //        DiffRecursive(
+            //            path + $"{i}.",
+            //            customPath + $"{i}.",
+            //            prop,
+            //            underlyingType,
+            //            curL,
+            //            curR,
+            //            diffs,
+            //            actions
+            //        );
+            //    }
+
+            //    return true;
+            //}
+
+            // Combine the keys from both dictionaries
+            var allKeys = new HashSet<object>();
+            if (leftDict != null)
             {
-                return attr.Name;
+                foreach (var key in leftDict.Keys)
+                {
+                    allKeys.Add(key);
+                }
+            }
+            if (rightDict != null)
+            {
+                foreach (var key in rightDict.Keys)
+                {
+                    allKeys.Add(key);
+                }
             }
 
-            var segments = attr.Name.Split('.');
-            var nestedProp = prop;
-            var nestedType = type;
-            object nestedLeft = left;
-            object nestedRight = right;
-
-            for (var i = 0; i < segments.Length; i++)
+            // Compare values associated with each key
+            foreach (var key in allKeys)
             {
-                nestedProp = nestedType?.GetProperty(segments[i]);
-                if (nestedProp is null)
-                {
-                    return attr.Name;
-                }
+                var leftValue = leftDict != null && leftDict.Contains(key) ? leftDict[key] : null;
+                var rightValue = rightDict != null && rightDict.Contains(key) ? rightDict[key] : null;
 
-                nestedType = nestedProp.PropertyType;
-                if (nestedType.IsIterable())
-                {
-                    return attr.Name;
-                }
+                // Construct paths using the dictionary key
+                var keyStr = key.ToString();
+                var fullPath = $"{path}{keyStr}";
+                var customFullPath = $"{customPath}{keyStr}";
 
-                if (i < segments.Length - 1)
-                {
-                    nestedLeft = TryGetValue(nestedProp, nestedLeft);
-                    nestedRight = TryGetValue(nestedProp, nestedRight);
-                }
+                DiffRecursive(
+                    fullPath + ".",
+                    customFullPath + ".",
+                    prop,
+                    valueType,
+                    leftValue,
+                    rightValue,
+                    diffs,
+                    actions
+                );
             }
 
-            var customName = (TryGetValue(nestedProp, nestedRight) ?? TryGetValue(nestedProp, nestedLeft))?.ToString();
-
-            return customName ?? attr.Name;
-        }
-
-        [CanBeNull]
-        private static object TryGetValue(PropertyInfo prop, object obj)
-        {
-            return obj is not null ? prop.GetValue(obj) : null;
+            return true;
         }
 
         private static bool HandleIterable<T>(
@@ -298,6 +359,57 @@ namespace Differ.DotNet
 
             diffs.Diffs.Add(diff.FullPath, diff);
             return true;
+        }
+
+        private static string GetCustomPropertyName<T>(Type type, T left, T right, PropertyInfo prop)
+        {
+            var attr = prop?.GetCustomAttribute<DiffPropertyName>();
+            if (attr is null)
+            {
+                return null;
+            }
+
+            if (attr.FromPropertyValue == false)
+            {
+                return attr.Name;
+            }
+
+            var segments = attr.Name.Split('.');
+            var nestedProp = prop;
+            var nestedType = type;
+            object nestedLeft = left;
+            object nestedRight = right;
+
+            for (var i = 0; i < segments.Length; i++)
+            {
+                nestedProp = nestedType?.GetProperty(segments[i]);
+                if (nestedProp is null)
+                {
+                    return attr.Name;
+                }
+
+                nestedType = nestedProp.PropertyType;
+                if (nestedType.IsIterable())
+                {
+                    return attr.Name;
+                }
+
+                if (i < segments.Length - 1)
+                {
+                    nestedLeft = TryGetValue(nestedProp, nestedLeft);
+                    nestedRight = TryGetValue(nestedProp, nestedRight);
+                }
+            }
+
+            var customName = (TryGetValue(nestedProp, nestedRight) ?? TryGetValue(nestedProp, nestedLeft))?.ToString();
+
+            return customName ?? attr.Name;
+        }
+
+        [CanBeNull]
+        private static object TryGetValue(PropertyInfo prop, object obj)
+        {
+            return obj is not null ? prop.GetValue(obj) : null;
         }
     }
 }

--- a/source/Perun.Differ/DifferDotNet.cs
+++ b/source/Perun.Differ/DifferDotNet.cs
@@ -148,49 +148,6 @@ namespace Differ.DotNet
             var leftDict = leftObj as IDictionary;
             var rightDict = rightObj as IDictionary;
 
-            //// Check for DiffArrayIdPropertyName attribute
-            //PropertyInfo idProperty = null;
-            //if (prop != null && prop.GetCustomAttribute<DiffCollectionId>() is { } idAttr)
-            //{
-            //    idProperty = underlyingType?.GetProperty(idAttr.Name);
-            //}
-
-            //// key based
-            //if (idProperty != null)
-            //{
-            //    var leftMap = leftArr.ToDictionary(idProperty.GetValue);
-            //    var rightMap = rightArr.ToDictionary(idProperty.GetValue);
-
-            //    var mapPairs = leftMap.Concat(rightMap).GroupBy(x => x.Key)
-            //        .ToDictionary(
-            //            x => x.Key,
-            //            x => (
-            //                Left: leftMap.ContainsKey(x.Key) ? leftMap[x.Key] : null,
-            //                Right: rightMap.ContainsKey(x.Key) ? rightMap[x.Key] : null
-            //            )
-            //        );
-
-            //    for (var i = 0; i < mapPairs.Count; i++)
-            //    {
-            //        var pair = mapPairs.ElementAt(i);
-            //        var curL = pair.Value.Left;
-            //        var curR = pair.Value.Right;
-
-            //        DiffRecursive(
-            //            path + $"{i}.",
-            //            customPath + $"{i}.",
-            //            prop,
-            //            underlyingType,
-            //            curL,
-            //            curR,
-            //            diffs,
-            //            actions
-            //        );
-            //    }
-
-            //    return true;
-            //}
-
             // Combine the keys from both dictionaries
             var allKeys = new HashSet<object>();
             if (leftDict != null)

--- a/source/Perun.Differ/Extensions.cs
+++ b/source/Perun.Differ/Extensions.cs
@@ -55,9 +55,24 @@ namespace Differ.DotNet
                 return false;
             }
 
-            var typeDef = type.GetGenericTypeDefinition();
+            var genericTypeDefinition = type.GetGenericTypeDefinition();
 
-            return typeDef == typeof(Dictionary<,>);
+            return genericTypeDefinition == typeof(IDictionary<,>) ||
+                   type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+        }
+
+        internal static bool IsSet(this Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                return false;
+            }
+
+            var genericTypeDefinition = type.GetGenericTypeDefinition();
+
+            return genericTypeDefinition == typeof(ISet<>) ||
+                   genericTypeDefinition == typeof(HashSet<>) ||
+                   type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ISet<>));
         }
 
         internal static Type GetIterableType(this Type type)
@@ -68,15 +83,6 @@ namespace Differ.DotNet
             }
 
             var genericArguments = type.GetGenericArguments();
-
-            if (genericArguments.Length == 2)
-            {
-                var dictionaryType = typeof(IDictionary<,>).MakeGenericType(genericArguments);
-                if (dictionaryType.IsAssignableFrom(type))
-                {
-                    return typeof(KeyValuePair<,>).MakeGenericType(genericArguments);
-                }
-            }
 
             return genericArguments.FirstOrDefault();
         }


### PR DESCRIPTION
User request https://github.com/maranmaran/dotnet-differ/issues/14

# Motivation

Support drilling into key-value types like Dictionary. 
To allow for retrieving deep diff results.

# TODO

Rethink sets/maps and allow for more robust equality / key diffing